### PR TITLE
Some changes to fix compilation with sles11sp1 2.6.32

### DIFF
--- a/hv-rhel6.x/hv/hyperv_fb.c
+++ b/hv-rhel6.x/hv/hyperv_fb.c
@@ -599,8 +599,10 @@ static int kstrtouint(const char *s, unsigned int base, unsigned int *res)
 	int result;
 	char *endbufp = NULL;
 
-	result = (int)simple_strtoul(s, &endbufp, 10);
-	return result;
+	result = simple_strtoul(s, &endbufp, base);
+	if (result > 0)
+		*res = result;
+	return 0;
 }
 
 

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -23,6 +23,13 @@
 #include <scsi/scsi_eh.h>
 #include <scsi/scsi_host.h>
 
+#if (defined(CONFIG_SUSE_KERNEL) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 32))
+#define VLAN_PRIO_MASK		0xe000 /* Priority Code Point */
+#define VLAN_PRIO_SHIFT		13
+#define VLAN_CFI_MASK		0x1000 /* Canonical Format Indicator */
+#define VLAN_TAG_PRESENT	VLAN_CFI_MASK
+#endif
+
 #ifdef CONFIG_MEMORY_HOTPLUG
 #undef CONFIG_MEMORY_HOTPLUG
 #endif

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -51,7 +51,7 @@ static inline int uuid_le_cmp(const uuid_le u1, const uuid_le u2)
 }
 #endif
 
-#if defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE < 1539)
+#if (defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE < 1539)) || (defined(CONFIG_SUSE_KERNEL) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 32))
 static inline struct page *skb_frag_page(const skb_frag_t *frag)
 {
 	return frag->page;

--- a/hv-rhel6.x/hv/include/linux/hv_compat.h
+++ b/hv-rhel6.x/hv/include/linux/hv_compat.h
@@ -51,7 +51,7 @@
 #define DID_TARGET_FAILURE	0x10
 #endif
 
-#if defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE < 1537)
+#if (defined(RHEL_RELEASE_VERSION) && (RHEL_RELEASE_CODE < 1537)) || (defined(CONFIG_SUSE_KERNEL) && LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 32))
 static inline int uuid_le_cmp(const uuid_le u1, const uuid_le u2)
 {
 	return memcmp(&u1, &u2, sizeof(uuid_le));

--- a/hv-rhel6.x/hv/netvsc_drv.c
+++ b/hv-rhel6.x/hv/netvsc_drv.c
@@ -344,6 +344,7 @@ static int netvsc_change_mtu(struct net_device *ndev, int mtu)
 }
 
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)
 static int netvsc_set_mac_addr(struct net_device *ndev, void *p)
 {
 	struct net_device_context *ndevctx = netdev_priv(ndev);
@@ -369,6 +370,7 @@ static int netvsc_set_mac_addr(struct net_device *ndev, void *p)
 
 	return err;
 }
+#endif
 
 
 static const struct ethtool_ops ethtool_ops = {
@@ -383,7 +385,9 @@ static const struct net_device_ops device_ops = {
 	.ndo_set_rx_mode =		netvsc_set_multicast_list,
 	.ndo_change_mtu =		netvsc_change_mtu,
 	.ndo_validate_addr =		eth_validate_addr,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 36)
 	.ndo_set_mac_address =		netvsc_set_mac_addr,
+#endif
 };
 
 /*


### PR DESCRIPTION
 Fix kstrtouint in hyperv_fb
 define uuid_le_cmp for sles11sp1 2.6.32
 Disable ndo_set_mac_address due to missing addr_assign_type
 define VLAN_TAG_PRESENT for sles11sp1 2.6.32
 Enable skb_frag compat for sles11sp1 2.6.32
